### PR TITLE
move print out of loop to prevent duplicate lines

### DIFF
--- a/src/tcp.c
+++ b/src/tcp.c
@@ -533,9 +533,9 @@ tcp_tls_connect(void)
     /* At this point, we are going to hand off control to OpenSSL
      * for them to establish the connection */
     timeof_ssl_start = time(0);
+    STATUS(1, "STARTTLS starting TLS ...\n");
 	do
 	{
-        STATUS(1, "STARTTLS starting TLS ...\n");
 		err = SSL_connect(g_ssl);
         if (timeof_ssl_start + g_scan_timeout < time(0)) {
             RESULT("UNKNOWN - SSL protocol error - connect timeout\n");


### PR DESCRIPTION
this debug log status line was being printed thousands of times on some situations:

"STARTTLS starting TLS ...\n"

I moved it out of the while loop so it only gets printed once.