### PR TITLE
Increase timeouts values for MST120 and TCP. Gives SAFE or VULNERABLE…

### DIFF
--- a/src/mst120.c
+++ b/src/mst120.c
@@ -12,7 +12,7 @@
 #endif
 
 #define MST120_SEND_MAX 5
-const unsigned MST120_TIMEOUT = 6;  // in seconds
+const unsigned MST120_TIMEOUT = 18;  // in seconds
 
 static VCHANNEL *mst120_channel;
 static int g_check_count;

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -45,7 +45,7 @@ int g_connect_retries = 4;
 int g_is_iso_confirmed = 0; /* Whether we got an ISO TPKT confimration */
 char g_targetaddr[256];
 char g_targetport[8];
-int g_scan_timeout = 20;
+int g_scan_timeout = 30;
 #ifdef WITH_SCARD
 #define STREAM_COUNT 8
 #else


### PR DESCRIPTION
… messages for about 10% of systems which gave UNKNOWN-timeout with old values. (Perfect solution would be timeout in command line parameters.)